### PR TITLE
feat: configuration endpoint for client id and secret

### DIFF
--- a/clientapp/__init__.py
+++ b/clientapp/__init__.py
@@ -51,6 +51,7 @@ dictConfig({
 })
 '''
 
+
 def get_preselected_provider():
     provider_id_string = cfg.PRE_SELECTED_PROVIDER_ID
     provider_object = '{ "provider" : "%s" }' % provider_id_string
@@ -135,7 +136,6 @@ def create_app():
                 status = 200
         return jsonify(data), status
 
-
     @app.route('/protected-content', methods=['GET'])
     def protected_content():
         app.logger.debug('/protected-content - cookies = %s' % request.cookies)
@@ -208,6 +208,12 @@ def create_app():
                                  content['provider_id'])
 
                 return jsonify({"provider_id": content['provider_id']}), 200
+
+            elif "client_id" in content and "client_secret" in content:
+                ''' Setup client_id and client_secret '''
+                oauth.op.client_id = content['client_id']
+                oauth.op.client_secret = content['client_secret']
+                return {}, 200
         else:
             return {}, 400
 

--- a/clientapp/__init__.py
+++ b/clientapp/__init__.py
@@ -201,7 +201,7 @@ def create_app():
 
     @app.route("/configuration", methods=["POST"])
     def configuration():
-        '''Receives client configuration via API'''
+        # Receives client configuration via API
         app.logger.info('/configuration called')
         content = request.json
         app.logger.debug("content = %s" % content)
@@ -215,7 +215,7 @@ def create_app():
                 return jsonify({"provider_id": content['provider_id']}), 200
 
             elif "client_id" in content and "client_secret" in content:
-                ''' Setup client_id and client_secret '''
+                # Setup client_id and client_secret
                 oauth.op.client_id = content['client_id']
                 oauth.op.client_secret = content['client_secret']
                 return {}, 200

--- a/clientapp/__init__.py
+++ b/clientapp/__init__.py
@@ -214,7 +214,7 @@ def create_app():
 
                 return jsonify({"provider_id": content['provider_id']}), 200
 
-            elif "client_id" in content and "client_secret" in content:
+            if "client_id" in content and "client_secret" in content:
                 # Setup client_id and client_secret
                 oauth.op.client_id = content['client_id']
                 oauth.op.client_secret = content['client_secret']

--- a/clientapp/__init__.py
+++ b/clientapp/__init__.py
@@ -106,17 +106,22 @@ def create_app():
 
     @app.route('/register', methods=['POST'])
     def register():
+        app.logger.info('/register called')
+        content = request.json
+        app.logger.debug('data = %s' % content)
+        app.logger.info('Trying to register client %s on %s' %
+                        (content['client_url'], content['op_url']))
         status = 0
         data = ''
-        if request.json is None:
+        if content is None:
             status = 400
             # message = 'No json data posted'
-        elif 'op_url' and 'client_url' not in request.json:
+        elif 'op_url' and 'client_url' not in content:
             status = 400
             # message = 'Not needed keys found in json'
         else:
-            op_url = request.json['op_url']
-            client_url = request.json['client_url']
+            op_url = content['op_url']
+            client_url = content['client_url']
 
             op_parsed_url = urlparse(op_url)
             client_parsed_url = urlparse(client_url)
@@ -129,8 +134,8 @@ def create_app():
 
             else:
                 client_handler = ClientHandler(
-                    request.json['op_url'],
-                    request.json['client_url']
+                    content['op_url'],
+                    content['client_url']
                 )
                 data = client_handler.get_client_dict()
                 status = 200

--- a/clientapp/config.py
+++ b/clientapp/config.py
@@ -1,5 +1,5 @@
-CLIENT_ID = "6fffd04d-8cbb-4989-8e17-ece3d92ff7c5"
-CLIENT_SECRET = "92f7c172-6d51-4159-98a5-58d9ead7c9e1"
+CLIENT_ID = "a7e1125da-b164-4aa9-85e9-456f510c7eda"
+CLIENT_SECRET = "a911acfa2-c4e2-4258-987c-af47864be058"
 CLIENT_AUTH_URI = "https://t1.techno24x7.com/oxauth/restv1/authorize"
 TOKEN_URI = "https://t1.techno24x7.com/oxauth/restv1/token"
 USERINFO_URI = "https://t1.techno24x7.com/oxauth/restv1/userinfo"
@@ -20,7 +20,7 @@ SERVER_TOKEN_AUTH_METHOD = "client_secret_post"
 # for gluu
 ACR_VALUES = 'passport_saml'
 PRE_SELECTED_PROVIDER = True
-PRE_SELECTED_PROVIDER_ID = 'saml-default'
+PRE_SELECTED_PROVIDER_ID = ''
 
 # SYSTEM SETTINGS
 # use with caution, unsecure requests, for develpment environments

--- a/tests/unit_integration/test_configuration_endpoint.py
+++ b/tests/unit_integration/test_configuration_endpoint.py
@@ -104,7 +104,7 @@ class TestConfigurationEndpoint(FlaskBaseTestCase):
             "client_secret": client_secret,
             "op_metadata_url": op_metadata_url
         })
-        response = self.client.post(
+        self.client.post(
             url_for('configuration'), data=json_data, headers=headers)
         self.assertTrue(clientapp.oauth.op.client_id == client_id,
                         'endpoint is NOT changing op.client_id')
@@ -113,7 +113,7 @@ class TestConfigurationEndpoint(FlaskBaseTestCase):
         headers = {'Content-type': 'application/json'}
         json_data = json.dumps(valid_client_configuration())
         client_secret = valid_client_configuration()['client_secret']
-        response = self.client.post(
+        self.client.post(
             url_for('configuration'), data=json_data, headers=headers)
         self.assertTrue(clientapp.oauth.op.client_secret == client_secret,
                         '%s is is not %s' % (clientapp.oauth.op.client_secret, client_secret))

--- a/tests/unit_integration/test_configuration_endpoint.py
+++ b/tests/unit_integration/test_configuration_endpoint.py
@@ -16,6 +16,14 @@ def app_endpoints(app: Flask) -> List[str]:
     return endpoints
 
 
+def valid_client_configuration():
+    return {
+        "client_id": "my-client-id",
+        "client_secret": "my-client-secret",
+        "op_metadata_url": "https://op.com/.well-known/openidconfiguration"
+    }
+
+
 class FlaskBaseTestCase(TestCase):
     def setUp(self):
         self.app = clientapp.create_app()
@@ -77,3 +85,35 @@ class TestConfigurationEndpoint(FlaskBaseTestCase):
                                     headers=headers)
 
         self.assertTrue(clientapp.cfg.PRE_SELECTED_PROVIDER, )
+
+    def test_endpoint_should_return_200_if_valid_client_config(self):
+        headers = {'Content-type': 'application/json'}
+        json_data = json.dumps(valid_client_configuration())
+        response = self.client.post(
+            url_for('configuration'), data=json_data, headers=headers)
+        self.assertEqual(response.status_code, 200,
+                         'endpoint is NOT returning 200 for valid client configuration')
+
+    def test_endpoint_should_register_new_oauth_client_id(self):
+        headers = {'Content-type': 'application/json'}
+        client_id = "my-client-id"
+        client_secret = "my-client-secret"
+        op_metadata_url = "https://op.com/.well-known/openidconfiguration"
+        json_data = json.dumps({
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "op_metadata_url": op_metadata_url
+        })
+        response = self.client.post(
+            url_for('configuration'), data=json_data, headers=headers)
+        self.assertTrue(clientapp.oauth.op.client_id == client_id,
+                        'endpoint is NOT changing op.client_id')
+
+    def test_endpoint_should_register_new_oauth_client_secret(self):
+        headers = {'Content-type': 'application/json'}
+        json_data = json.dumps(valid_client_configuration())
+        client_secret = valid_client_configuration()['client_secret']
+        response = self.client.post(
+            url_for('configuration'), data=json_data, headers=headers)
+        self.assertTrue(clientapp.oauth.op.client_secret == client_secret,
+                        '%s is is not %s' % (clientapp.oauth.op.client_secret, client_secret))

--- a/tests/unit_integration/test_configuration_endpoint.py
+++ b/tests/unit_integration/test_configuration_endpoint.py
@@ -69,9 +69,9 @@ class TestConfigurationEndpoint(FlaskBaseTestCase):
         headers = {'Content-type': 'application/json'}
         data = {'provider_id': 'whatever'}
         json_data = json.dumps(data)
-        response = self.client.post(url_for('configuration'),
-                                    data=json_data,
-                                    headers=headers)
+        self.client.post(url_for('configuration'),
+                         data=json_data,
+                         headers=headers)
 
         self.assertEqual(clientapp.cfg.PRE_SELECTED_PROVIDER_ID, 'whatever')
 
@@ -80,9 +80,9 @@ class TestConfigurationEndpoint(FlaskBaseTestCase):
         headers = {'Content-type': 'application/json'}
         data = {'provider_id': 'whatever'}
         json_data = json.dumps(data)
-        response = self.client.post(url_for('configuration'),
-                                    data=json_data,
-                                    headers=headers)
+        self.client.post(url_for('configuration'),
+                         data=json_data,
+                         headers=headers)
 
         self.assertTrue(clientapp.cfg.PRE_SELECTED_PROVIDER, )
 

--- a/tests/unit_integration/test_dynamic_client_registration.py
+++ b/tests/unit_integration/test_dynamic_client_registration.py
@@ -9,7 +9,7 @@ import helper
 ClientHandler = client_handler.ClientHandler
 
 
-#helper
+# helper
 def get_class_instance(op_url='https://t1.techno24x7.com',
                        client_url='https://mock.test.com'):
     client_handler_obj = ClientHandler(op_url, client_url)
@@ -83,8 +83,8 @@ class TestDynamicClientRegistration(TestCase):
             '_ClientHandler__client_secret',
             '_ClientHandler__client_url',
             '_ClientHandler__metadata_url',
-            'discover',  #method
-            'register_client'  #method
+            'discover',  # method
+            'register_client'  # method
         ]
 
         self.assertTrue(


### PR DESCRIPTION
sending `client_id`, `client_secret` and `op_metadata_url` through `POST /configuration` updates client configuration